### PR TITLE
[CI/CD] Update CI/CD Actions File

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,11 +74,11 @@ jobs:
         with:
           context: ./Back-end
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/getemployed-backend/latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/getemployed-backend:latest
 
       - name: Build and push frontend
         uses: docker/build-push-action@v5
         with:
           context: ./Front-end
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/getemployed-frontend/latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/getemployed-frontend:latest


### PR DESCRIPTION
The commands to push images to Docker Hub had bad syntax. Just a couple lines had to be changed. Hopefully this is the reason for the denied requests to push.